### PR TITLE
ISSUE-16 - Implemented Issue #16 with a CSS-only change to make the W…

### DIFF
--- a/cocktailchooser-frontend/src/App.vue
+++ b/cocktailchooser-frontend/src/App.vue
@@ -788,8 +788,18 @@ button:disabled {
 }
 
 .match-list {
-  margin: 0;
-  padding-left: 1rem;
+  margin: 0.75rem 0 0;
+  padding: 0;
+  list-style: none;
+  column-width: 18rem;
+  column-gap: 1rem;
+}
+
+.match-list li {
+  break-inside: avoid;
+  display: flex;
+  align-items: center;
+  margin-bottom: 0.35rem;
 }
 
 .match-list button {
@@ -797,6 +807,7 @@ button:disabled {
   background: transparent;
   color: #0b5a85;
   padding: 0;
+  text-align: left;
 }
 
 .detail {
@@ -853,6 +864,11 @@ button:disabled {
   .grid,
   .detail-grid {
     grid-template-columns: 1fr;
+  }
+
+  .match-list {
+    column-width: auto;
+    column-count: 1;
   }
 }
 </style>


### PR DESCRIPTION
…hat Can I Drink list wrap into responsive columns on larger screens.

What changed:

App.vue
.match-list now uses CSS multi-column layout (column-width) so the browser calculates column count based on available width. List items use break-inside: avoid so entries don’t split across columns. Mobile (max-width: 900px) is forced back to a single column.
 Changes to be committed:
	modified:   cocktailchooser-frontend/src/App.vue